### PR TITLE
[RAC-6071] Create catalog task - practice topic-1 of training camp

### DIFF
--- a/lib/graphs/discovery-graph.js
+++ b/lib/graphs/discovery-graph.js
@@ -90,6 +90,13 @@ module.exports = {
             ignoreFailure: true
         },
         {
+            label: 'catalog-lsfileinfo',
+            taskName: 'Task.Catalog.lsfileinfo',
+            waitOn: {
+                'catalog-lldp': 'finished'
+            }
+        },
+        {
             "label": "set-boot-pxe",
             "taskDefinition": {
                 "friendlyName": "Set PXE boot",
@@ -101,7 +108,7 @@ module.exports = {
                 "properties": {}
             },
             waitOn: {
-               'catalog-lldp': 'finished'
+               'catalog-lsfileinfo': 'finished'
             }
         },
         {


### PR DESCRIPTION
Background
This PR aims to follow up the practice of creating catalog task.

Details
In order to run up a new catalog task, a new task is needed. And then this task should be added to the discovery taskgraph.
So, in on-taskgraph repo, I added the new task into discovery taskgraph.

Reviewer
@iceiilin @leoyjchang
